### PR TITLE
`vm_name` is now an optional parameter 

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,15 +91,11 @@ This will clone `10.15.6` to a new VM and, if there are differences from the bas
 
 * `installer_app` (String)
 
-The path to a macOS installer. This process takes about 20 minutes. The resulting VM template name will be `{{vm_name}}-{{macOSVersion}}`. macOSVersion is pulled from the installer app.
+The path to a macOS installer. This process takes about 20 minutes.
 
 * `type` (String)
 
 Must be `veertu-anka-vm-create`.
-
-* `vm_name` (String)
-
-The name for the VM that is created. One is generated if not provided (`anka-packer-{10RandomCharacters}`).
 
 #### Optional Configuration
 
@@ -161,6 +157,14 @@ The size in "[0-9]+G" format, defaults to `2G`.
 
 Whether or not to stop the vm after it has been created, defaults to false.
 
+* `use_anka_cp` (Boolean)
+
+Use built in anka cp command. Defaults to false.
+
+* `vm_name` (String)
+
+The name for the VM that is created. One is generated with installer_app data if not provided (`anka-packer-base-{{ installer_app.OSVersion }}-{{ installer_app.BundlerVersion }}`).
+
 ### veertu-anka-vm-clone
 
 #### Required Configuration
@@ -172,10 +176,6 @@ The VM to clone for provisioning, either stopped or suspended.
 * `type` (String)
 
 Must be `veertu-anka-vm-clone`.
-
-* `vm_name` (String)
-
-The name for the VM that is created. One is generated if not provided (`anka-packer-{10RandomCharacters}`).
 
 #### Optional Configuration
 
@@ -264,6 +264,14 @@ Whether or not to stop the vm after it has been created, defaults to false.
 * `update_addons` (Boolean)
 
 Update the vm addons. Defaults to false.
+
+* `use_anka_cp` (Boolean)
+
+Use built in anka cp command. Defaults to false.
+
+* `vm_name` (String)
+
+The name for the VM that is created. One is generated using the source_vm_name if not provided (`{{ source_vm_name }}-{10RandomChars}`).
 
 ## Post Processors
 

--- a/builder/anka/step_clone_vm.go
+++ b/builder/anka/step_clone_vm.go
@@ -23,9 +23,9 @@ type StepCloneVM struct {
 func (s *StepCloneVM) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
-	util := state.Get("util").(util.Util)
+	ankaUtil := state.Get("util").(util.Util)
 	onError := func(err error) multistep.StepAction {
-		return util.StepError(ui, state, err)
+		return ankaUtil.StepError(ui, state, err)
 	}
 	sourceVMTag := "latest"
 	doPull := config.AlwaysFetch
@@ -36,6 +36,10 @@ func (s *StepCloneVM) Run(ctx context.Context, state multistep.StateBag) multist
 
 	s.client = state.Get("client").(client.Client)
 	s.vmName = config.VMName
+
+	if s.vmName == "" {
+		s.vmName = fmt.Sprintf("%s-%s", config.SourceVMName, ankaUtil.RandSeq(10))
+	}
 
 	state.Put("vm_name", s.vmName)
 
@@ -110,7 +114,7 @@ func (s *StepCloneVM) Run(ctx context.Context, state multistep.StateBag) multist
 		return onError(err)
 	}
 
-	err = s.modifyVMResources(clonedShow, config, ui, util)
+	err = s.modifyVMResources(clonedShow, config, ui, ankaUtil)
 	if err != nil {
 		return onError(err)
 	}

--- a/builder/anka/step_set_generated_data_test.go
+++ b/builder/anka/step_set_generated_data_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/packerbuilderdata"
-	c "github.com/veertuinc/packer-builder-veertu-anka/client"
+	"github.com/veertuinc/packer-builder-veertu-anka/client"
 	mocks "github.com/veertuinc/packer-builder-veertu-anka/mocks"
 	"gotest.tools/assert"
 )
@@ -17,8 +17,8 @@ import (
 func TestSetGeneratedDataRun(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
-	client := mocks.NewMockClient(mockCtrl)
-	util := mocks.NewMockUtil(mockCtrl)
+	ankaClient := mocks.NewMockClient(mockCtrl)
+	ankaUtil := mocks.NewMockUtil(mockCtrl)
 
 	state := new(multistep.BasicStateBag)
 	step := StepSetGeneratedData{
@@ -27,27 +27,27 @@ func TestSetGeneratedDataRun(t *testing.T) {
 	}
 	ui := packer.TestUi(t)
 	ctx := context.Background()
-	darwinVersion := c.RunParams{
+	darwinVersion := client.RunParams{
 		Command: []string{"/usr/bin/uname", "-r"},
 		VMName:  step.vmName,
 		Stdout:  &bytes.Buffer{},
 	}
-	osv := c.RunParams{
+	osv := client.RunParams{
 		Command: []string{"/usr/bin/sw_vers", "-productVersion"},
 		VMName:  step.vmName,
 		Stdout:  &bytes.Buffer{},
 	}
 
 	state.Put("ui", ui)
-	state.Put("util", util)
+	state.Put("client", ankaClient)
+	state.Put("util", ankaUtil)
 
 	t.Run("expose variables", func(t *testing.T) {
 		state.Put("vm_name", step.vmName)
-		state.Put("client", client)
 
 		gomock.InOrder(
-			client.EXPECT().Run(darwinVersion).Times(1),
-			client.EXPECT().Run(osv).Times(1),
+			ankaClient.EXPECT().Run(darwinVersion).Times(1),
+			ankaClient.EXPECT().Run(osv).Times(1),
 		)
 
 		stepAction := step.Run(ctx, state)

--- a/builder/anka/step_start_vm_test.go
+++ b/builder/anka/step_start_vm_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
-	c "github.com/veertuinc/packer-builder-veertu-anka/client"
+	"github.com/veertuinc/packer-builder-veertu-anka/client"
 	mocks "github.com/veertuinc/packer-builder-veertu-anka/mocks"
 	"gotest.tools/assert"
 )
@@ -16,8 +16,8 @@ import (
 func TestStartVMRun(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
-	client := mocks.NewMockClient(mockCtrl)
-	util := mocks.NewMockUtil(mockCtrl)
+	ankaClient := mocks.NewMockClient(mockCtrl)
+	ankaUtil := mocks.NewMockUtil(mockCtrl)
 
 	step := StepStartVM{}
 	ui := packer.TestUi(t)
@@ -25,16 +25,16 @@ func TestStartVMRun(t *testing.T) {
 	state := new(multistep.BasicStateBag)
 
 	state.Put("ui", ui)
-	state.Put("util", util)
+	state.Put("client", ankaClient)
+	state.Put("util", ankaUtil)
 	state.Put("vm_name", "foo")
 
 	t.Run("start vm", func(t *testing.T) {
 		config := &Config{}
 
-		state.Put("client", client)
 		state.Put("config", config)
 
-		client.EXPECT().Start(c.StartParams{VMName: "foo"}).Return(nil).Times(1)
+		ankaClient.EXPECT().Start(client.StartParams{VMName: "foo"}).Return(nil).Times(1)
 
 		stepAction := step.Run(ctx, state)
 		assert.Equal(t, multistep.ActionContinue, stepAction)
@@ -48,10 +48,9 @@ func TestStartVMRun(t *testing.T) {
 		mockui := packer.MockUi{}
 		mockui.Say(fmt.Sprintf("Waiting for %s for clone to boot", config.BootDelay))
 
-		state.Put("client", client)
 		state.Put("config", config)
 
-		client.EXPECT().Start(c.StartParams{VMName: "foo"}).Return(nil).Times(1)
+		ankaClient.EXPECT().Start(client.StartParams{VMName: "foo"}).Return(nil).Times(1)
 
 		stepAction := step.Run(ctx, state)
 		assert.Equal(t, mockui.SayMessages[0].Message, "Waiting for 1s for clone to boot")
@@ -61,12 +60,11 @@ func TestStartVMRun(t *testing.T) {
 	t.Run("start vm but fail to start", func(t *testing.T) {
 		config := &Config{}
 
-		state.Put("client", client)
 		state.Put("config", config)
 
 		gomock.InOrder(
-			client.EXPECT().Start(c.StartParams{VMName: "foo"}).Return(fmt.Errorf("failed to start vm %s", "foo")).Times(1),
-			util.EXPECT().StepError(ui, state, fmt.Errorf("failed to start vm %s", "foo")).Return(multistep.ActionHalt).Times(1),
+			ankaClient.EXPECT().Start(client.StartParams{VMName: "foo"}).Return(fmt.Errorf("failed to start vm %s", "foo")).Times(1),
+			ankaUtil.EXPECT().StepError(ui, state, fmt.Errorf("failed to start vm %s", "foo")).Return(multistep.ActionHalt).Times(1),
 		)
 
 		stepAction := step.Run(ctx, state)

--- a/mocks/util_mock.go
+++ b/mocks/util_mock.go
@@ -81,6 +81,20 @@ func (mr *MockUtilMockRecorder) ObtainMacOSVersionFromInstallerApp(path interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObtainMacOSVersionFromInstallerApp", reflect.TypeOf((*MockUtil)(nil).ObtainMacOSVersionFromInstallerApp), path)
 }
 
+// RandSeq mocks base method.
+func (m *MockUtil) RandSeq(n int) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RandSeq", n)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// RandSeq indicates an expected call of RandSeq.
+func (mr *MockUtilMockRecorder) RandSeq(n interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RandSeq", reflect.TypeOf((*MockUtil)(nil).RandSeq), n)
+}
+
 // StepError mocks base method.
 func (m *MockUtil) StepError(ui packer.Ui, state multistep.StateBag, err error) multistep.StepAction {
 	m.ctrl.T.Helper()

--- a/util/util.go
+++ b/util/util.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/groob/plist"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
@@ -16,10 +18,15 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/pathing"
 )
 
+var (
+	random  *rand.Rand
+	letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+)
+
 // InstallAppPlist is a list of variables that comes from the installer app
 type InstallAppPlist struct {
-	OSVersion         string `plist:"DTPlatformVersion"`
-	OSPlatformVersion string `plist:"CFBundleShortVersionString"`
+	OSVersion      string `plist:"DTPlatformVersion"`
+	BundlerVersion string `plist:"CFBundleShortVersionString"`
 }
 
 // Util defines everything this utility can do
@@ -27,6 +34,7 @@ type Util interface {
 	ConfigTmpDir() (string, error)
 	ConvertDiskSizeToBytes(diskSize string) (uint64, error)
 	ObtainMacOSVersionFromInstallerApp(path string) (InstallAppPlist, error)
+	RandSeq(n int) string
 	StepError(ui packer.Ui, state multistep.StateBag, err error) multistep.StepAction
 }
 
@@ -140,4 +148,15 @@ func (u *AnkaUtil) ConfigTmpDir() (string, error) {
 
 	log.Printf("Set Packer temp dir to %s", td)
 	return td, nil
+}
+
+func (u *AnkaUtil) RandSeq(n int) string {
+	random = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[random.Intn(len(letters))]
+	}
+
+	return string(b)
 }


### PR DESCRIPTION
This changes how we generate the `vm_name` name. If the config no longer sees a `vm_name` it will not fail and instead it will generate that name with data it knows about to make it unique.

Signed-off-by: Nathaniel Kierpiec <nkierpiec@chef.io>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
