### PR TITLE
Use default registry remotes if not specified in configuration

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -18,9 +18,8 @@ type Client interface {
 	Exists(vmName string) (bool, error)
 	License() (LicenseResponse, error)
 	Modify(vmName string, command string, property string, flags ...string) error
-	RegistryDefaultRepo() (RegistryListReposResponse, error)
 	RegistryList(registryParams RegistryParams) ([]RegistryListResponse, error)
-	RegistryListRepos() (map[string]RegistryListReposResponse, error)
+	RegistryListRepos() (RegistryListReposResponse, error)
 	RegistryPull(registryParams RegistryParams, pullParams RegistryPullParams) error
 	RegistryPush(registryParams RegistryParams, pushParams RegistryPushParams) error
 	RegistryRevert(url string, id string) error

--- a/client/client.go
+++ b/client/client.go
@@ -18,7 +18,9 @@ type Client interface {
 	Exists(vmName string) (bool, error)
 	License() (LicenseResponse, error)
 	Modify(vmName string, command string, property string, flags ...string) error
+	RegistryDefaultRepo() (RegistryListReposResponse, error)
 	RegistryList(registryParams RegistryParams) ([]RegistryListResponse, error)
+	RegistryListRepos() (map[string]RegistryListReposResponse, error)
 	RegistryPull(registryParams RegistryParams, pullParams RegistryPullParams) error
 	RegistryPush(registryParams RegistryParams, pushParams RegistryPushParams) error
 	RegistryRevert(url string, id string) error

--- a/client/client_registry.go
+++ b/client/client_registry.go
@@ -48,6 +48,54 @@ func (c *AnkaClient) RegistryList(registryParams RegistryParams) ([]RegistryList
 	return response, nil
 }
 
+type RegistryListReposResponse struct {
+	Default bool   `json:"default,omitempty"`
+	ID      string `json:"id,omitempty"`
+	Host    string `json:"host"`
+	Scheme  string `json:"scheme"`
+	Port    string `json:"port"`
+}
+
+func (c *AnkaClient) RegistryDefaultRepo() (RegistryListReposResponse, error) {
+	var response RegistryListReposResponse
+
+	output, err := runRegistryCommand(RegistryParams{}, "list-repos", "--default")
+	if err != nil {
+		return response, err
+	}
+	if output.Status != "OK" {
+		log.Print("Error using 'registry list-repos' to determine default registry: ", output.ExceptionType, " ", output.Message)
+		return response, fmt.Errorf(output.Message)
+	}
+
+	err = json.Unmarshal(output.Body, &response)
+	if err != nil {
+		return response, err
+	}
+
+	return response, nil
+}
+
+func (c *AnkaClient) RegistryListRepos() (map[string]RegistryListReposResponse, error) {
+	var response map[string]RegistryListReposResponse
+
+	output, err := runRegistryCommand(RegistryParams{}, "list-repos")
+	if err != nil {
+		return response, err
+	}
+	if output.Status != "OK" {
+		log.Print("Error executing 'registry list-repos' command: ", output.ExceptionType, " ", output.Message)
+		return response, fmt.Errorf(output.Message)
+	}
+
+	err = json.Unmarshal(output.Body, &response)
+	if err != nil {
+		return response, err
+	}
+
+	return response, nil
+}
+
 type RegistryPullParams struct {
 	VMID   string
 	Tag    string

--- a/client/client_registry.go
+++ b/client/client_registry.go
@@ -48,36 +48,20 @@ func (c *AnkaClient) RegistryList(registryParams RegistryParams) ([]RegistryList
 	return response, nil
 }
 
-type RegistryListReposResponse struct {
-	Default bool   `json:"default,omitempty"`
-	ID      string `json:"id,omitempty"`
+type RegistryRemote struct {
+	Default bool   `json:"default"`
 	Host    string `json:"host"`
 	Scheme  string `json:"scheme"`
 	Port    string `json:"port"`
 }
 
-func (c *AnkaClient) RegistryDefaultRepo() (RegistryListReposResponse, error) {
-	var response RegistryListReposResponse
-
-	output, err := runRegistryCommand(RegistryParams{}, "list-repos", "--default")
-	if err != nil {
-		return response, err
-	}
-	if output.Status != "OK" {
-		log.Print("Error using 'registry list-repos' to determine default registry: ", output.ExceptionType, " ", output.Message)
-		return response, fmt.Errorf(output.Message)
-	}
-
-	err = json.Unmarshal(output.Body, &response)
-	if err != nil {
-		return response, err
-	}
-
-	return response, nil
+type RegistryListReposResponse struct {
+	Default string
+	Remotes map[string]RegistryRemote
 }
 
-func (c *AnkaClient) RegistryListRepos() (map[string]RegistryListReposResponse, error) {
-	var response map[string]RegistryListReposResponse
+func (c *AnkaClient) RegistryListRepos() (RegistryListReposResponse, error) {
+	var response RegistryListReposResponse
 
 	output, err := runRegistryCommand(RegistryParams{}, "list-repos")
 	if err != nil {
@@ -88,9 +72,15 @@ func (c *AnkaClient) RegistryListRepos() (map[string]RegistryListReposResponse, 
 		return response, fmt.Errorf(output.Message)
 	}
 
-	err = json.Unmarshal(output.Body, &response)
+	err = json.Unmarshal(output.Body, &response.Remotes)
 	if err != nil {
 		return response, err
+	}
+
+	for name, remote := range response.Remotes {
+		if remote.Default {
+			response.Default = name
+		}
 	}
 
 	return response, nil

--- a/mocks/client_mock.go
+++ b/mocks/client_mock.go
@@ -155,21 +155,6 @@ func (mr *MockClientMockRecorder) Modify(vmName, command, property interface{}, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Modify", reflect.TypeOf((*MockClient)(nil).Modify), varargs...)
 }
 
-// RegistryDefaultRepo mocks base method.
-func (m *MockClient) RegistryDefaultRepo() (client.RegistryListReposResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegistryDefaultRepo")
-	ret0, _ := ret[0].(client.RegistryListReposResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// RegistryDefaultRepo indicates an expected call of RegistryDefaultRepo.
-func (mr *MockClientMockRecorder) RegistryDefaultRepo() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegistryDefaultRepo", reflect.TypeOf((*MockClient)(nil).RegistryDefaultRepo))
-}
-
 // RegistryList mocks base method.
 func (m *MockClient) RegistryList(registryParams client.RegistryParams) ([]client.RegistryListResponse, error) {
 	m.ctrl.T.Helper()
@@ -186,10 +171,10 @@ func (mr *MockClientMockRecorder) RegistryList(registryParams interface{}) *gomo
 }
 
 // RegistryListRepos mocks base method.
-func (m *MockClient) RegistryListRepos() (map[string]client.RegistryListReposResponse, error) {
+func (m *MockClient) RegistryListRepos() (client.RegistryListReposResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegistryListRepos")
-	ret0, _ := ret[0].(map[string]client.RegistryListReposResponse)
+	ret0, _ := ret[0].(client.RegistryListReposResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/mocks/client_mock.go
+++ b/mocks/client_mock.go
@@ -155,6 +155,21 @@ func (mr *MockClientMockRecorder) Modify(vmName, command, property interface{}, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Modify", reflect.TypeOf((*MockClient)(nil).Modify), varargs...)
 }
 
+// RegistryDefaultRepo mocks base method.
+func (m *MockClient) RegistryDefaultRepo() (client.RegistryListReposResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegistryDefaultRepo")
+	ret0, _ := ret[0].(client.RegistryListReposResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RegistryDefaultRepo indicates an expected call of RegistryDefaultRepo.
+func (mr *MockClientMockRecorder) RegistryDefaultRepo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegistryDefaultRepo", reflect.TypeOf((*MockClient)(nil).RegistryDefaultRepo))
+}
+
 // RegistryList mocks base method.
 func (m *MockClient) RegistryList(registryParams client.RegistryParams) ([]client.RegistryListResponse, error) {
 	m.ctrl.T.Helper()
@@ -168,6 +183,21 @@ func (m *MockClient) RegistryList(registryParams client.RegistryParams) ([]clien
 func (mr *MockClientMockRecorder) RegistryList(registryParams interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegistryList", reflect.TypeOf((*MockClient)(nil).RegistryList), registryParams)
+}
+
+// RegistryListRepos mocks base method.
+func (m *MockClient) RegistryListRepos() (map[string]client.RegistryListReposResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegistryListRepos")
+	ret0, _ := ret[0].(map[string]client.RegistryListReposResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RegistryListRepos indicates an expected call of RegistryListRepos.
+func (mr *MockClientMockRecorder) RegistryListRepos() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegistryListRepos", reflect.TypeOf((*MockClient)(nil).RegistryListRepos))
 }
 
 // RegistryPull mocks base method.

--- a/post-processor/ankaregistry/post-processor.go
+++ b/post-processor/ankaregistry/post-processor.go
@@ -67,6 +67,31 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 
 	p.client = &client.AnkaClient{}
 
+	if p.config.RegistryURL == "" {
+		var err error
+		var repoConfig client.RegistryListReposResponse
+
+		if p.config.RegistryName == "" {
+			repoConfig, err = p.client.RegistryDefaultRepo()
+			if err != nil {
+				return err
+			}
+		} else {
+			allRepoConfigs, err := p.client.RegistryListRepos()
+			if err != nil {
+				return err
+			}
+
+			var ok bool
+			repoConfig, ok = allRepoConfigs[p.config.RegistryName]
+			if !ok {
+				return fmt.Errorf("Could not find configuration for registry '%s'", p.config.RegistryName)
+			}
+		}
+
+		p.config.RegistryURL = fmt.Sprintf("%s://%s:%s", repoConfig.Scheme, repoConfig.Host, repoConfig.Port)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
If the registry settings are not provided in the configuration, pull them from the `anka cli` commands.

This addresses a bug where the `RegistryRevert` action would fail as part of a force push to the registry if you had not specified the URL. 

Signed-off-by: Tom Duffield <tom@chef.io>