### PR TITLE
Only revert tag on registry push when necessary

### DIFF
--- a/post-processor/ankaregistry/post-processor.go
+++ b/post-processor/ankaregistry/post-processor.go
@@ -126,6 +126,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 
 	if p.config.PackerForce {
 		var id string
+		var latestTag string
 
 		templates, err := p.client.RegistryList(registryParams)
 		if err != nil {
@@ -135,12 +136,13 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 		for i := 0; i < len(templates); i++ {
 			if templates[i].Name == remoteVMName {
 				id = templates[i].ID
+				latestTag = templates[i].Latest
 				ui.Say(fmt.Sprintf("Found existing template %s on registry that matches name '%s'", id, remoteVMName))
 				break
 			}
 		}
 
-		if id != "" {
+		if id != "" && latestTag == remoteTag {
 			err = p.client.RegistryRevert(registryParams.RegistryURL, id)
 			if err != nil {
 				return nil, false, false, err

--- a/post-processor/ankaregistry/post-processor_test.go
+++ b/post-processor/ankaregistry/post-processor_test.go
@@ -190,7 +190,56 @@ func TestAnkaRegistryPostProcessor(t *testing.T) {
 	})
 
 	t.Run("with force push to registry and existing templates", func(t *testing.T) {
-		err := json.Unmarshal(json.RawMessage(`[{ "id": "foo_id", "name": "foo" }]`), &templateList)
+		err := json.Unmarshal(json.RawMessage(`[{ "id": "foo_id", "name": "foo", "latest": "foo_tag" }]`), &templateList)
+		if err != nil {
+			t.Fail()
+		}
+
+		packerConfig := common.PackerConfig{
+			PackerForce: true,
+		}
+
+		config := Config{
+			PackerConfig: packerConfig,
+			RemoteVM:     "foo",
+			Tag:          "registry-push",
+			Description:  "mock for testing anka registry push",
+		}
+
+		pp := PostProcessor{
+			config: config,
+			client: ankaClient,
+		}
+
+		registryParams := client.RegistryParams{
+			RegistryName: "go-mock",
+			RegistryURL:  "http://localhost:8080",
+		}
+
+		pushParams := client.RegistryPushParams{
+			Tag:         config.Tag,
+			Description: config.Description,
+			RemoteVM:    config.RemoteVM,
+			Local:       false,
+		}
+
+		ankaClient.EXPECT().RegistryListRepos().Return(reposList, nil).Times(1)
+		ankaClient.EXPECT().RegistryList(registryParams).Return(templateList, nil).Times(1)
+		ankaClient.EXPECT().RegistryPush(registryParams, pushParams).Return(nil).Times(1)
+
+		mockui := packer.MockUi{}
+		mockui.Say(fmt.Sprintf("Pushing template to Anka Registry as %s with tag %s", config.RemoteVM, config.Tag))
+		mockui.Say(fmt.Sprintf("Found existing template %s on registry that matches name '%s'", templateList[0].ID, config.RemoteVM))
+
+		assert.Equal(t, mockui.SayMessages[0].Message, "Pushing template to Anka Registry as foo with tag registry-push")
+		assert.Equal(t, mockui.SayMessages[1].Message, "Found existing template foo_id on registry that matches name 'foo'")
+
+		_, _, _, err = pp.PostProcess(context.Background(), ui, artifact)
+		assert.Nil(t, err)
+	})
+
+	t.Run("with force push to registry and existing templates with latest tag match", func(t *testing.T) {
+		err := json.Unmarshal(json.RawMessage(`[{ "id": "foo_id", "name": "foo", "latest": "registry-push" }]`), &templateList)
 		if err != nil {
 			t.Fail()
 		}


### PR DESCRIPTION
The Anka Registry does not support deleting any random tag. Our only options are to delete ALL tags or "revert" the latest. During a force build, we only need to revert the latest tag if that tag matches the tag we're trying to push. Otherwise, we can leave it alone.

This does prevent us from successfully re-pushing an older tag.

Signed-off-by: Tom Duffield <github@tomduffield.com>